### PR TITLE
TAVGSFC

### DIFF
--- a/util/tavgsfc.py
+++ b/util/tavgsfc.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# tavgsfc.py v0.1 (2023-11-07)
+#
+# Inserts running mean lowest model level temperatures into WRF met_em
+# files. The new variable TAVGSFC is used by WRF as skin temperature
+# for lakes
+
+import argparse
+import glob
+import netCDF4 as nc
+import numpy as np
+import os
+import sys
+
+varname ='TAVGSFC'
+running_mean_days = 15
+files_per_day = 4
+
+def process_wrf_files(pattern, overwrite):
+  files = glob.glob(pattern)
+  files.sort()
+  
+  print(f'Inserting {running_mean_days}-day running mean into {varname}')
+  running_mean_buffer = []
+  for file_name in files:
+    print(file_name)
+    input_file = nc.Dataset(file_name, 'a')
+    tt = input_file.variables['TT'][:]
+    if len(running_mean_buffer) == running_mean_days * files_per_day:
+      # Remove the oldest time worth of data
+      running_mean_buffer.pop(0)
+    running_mean_buffer.append(tt[:, 0, :, :])
+    running_mean = np.mean(running_mean_buffer, axis=0)
+    if varname in input_file.variables:
+      print(f'WARNING: Variable {varname} already exists in {file_name}.')
+      if overwrite:
+        print('Overwriting...')
+        input_file.variables[varname][:] = running_mean
+      else:
+        print('Skipping...')
+        input_file.close()
+        continue
+    else:
+      tavgsfc = input_file.createVariable(varname, 'f4', ('Time', 'south_north', 'west_east'))
+      tavgsfc[:] = running_mean
+    input_file.close()
+  
+
+def main():
+  parser = argparse.ArgumentParser(description='Process WRF met_em files and add running mean temperature')
+  parser.add_argument('pattern', help='File pattern to match met_em files')
+  parser.add_argument('-O', '--overwrite', action='store_true', help='Overwrite TAVGSFC if it already exists')
+  args = parser.parse_args()
+  process_wrf_files(args.pattern, args.overwrite)
+
+if __name__ == "__main__":
+    main()

--- a/util/tavgsfc.py
+++ b/util/tavgsfc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# tavgsfc.py v0.1 (2023-11-07)
+# tavgsfc.py v0.2 (2023-11-08)
 #
 # Inserts running mean lowest model level temperatures into WRF met_em
 # files. The new variable TAVGSFC is used by WRF as skin temperature
@@ -43,14 +43,25 @@ def process_wrf_files(pattern, overwrite):
         continue
     else:
       tavgsfc = input_file.createVariable(varname, 'f4', ('Time', 'south_north', 'west_east'))
+      for attr_name in input_file.variables['TT'].ncattrs():
+        setattr(tavgsfc, attr_name, getattr(input_file.variables['TT'], attr_name))
+      setattr(tavgsfc, 'MemoryOrder', 'XY ')
       tavgsfc[:] = running_mean
+    # Add the global attribute flag
+    input_file.setncattr('FLAG_TAVGSFC', 1)
     input_file.close()
   
 
 def main():
-  parser = argparse.ArgumentParser(description='Process WRF met_em files and add running mean temperature')
-  parser.add_argument('pattern', help='File pattern to match met_em files')
-  parser.add_argument('-O', '--overwrite', action='store_true', help='Overwrite TAVGSFC if it already exists')
+  parser = argparse.ArgumentParser(
+    description='Process WRF met_em files and add running mean temperature'
+  )
+  parser.add_argument('pattern',
+    help='File pattern to match met_em files'
+  )
+  parser.add_argument('-O', '--overwrite', action='store_true',
+    help='Overwrite TAVGSFC if it already exists'
+  )
   args = parser.parse_args()
   process_wrf_files(args.pattern, args.overwrite)
 


### PR DESCRIPTION
We are planning to use the average near surface temperature to define the skin temperature for lakes. This is achieved by means of the [avg_tsfc.exe](https://github.com/wrf-model/WPS/blob/master/util/src/avg_tsfc.F) tool in WPS, which computes a TAVGSFC variable consisting of the average near-surface temperature for the time period being processed in namelist.wps. This avoids setting e.g. lake temperatures in the Alps to the closest SST, which would be in the Mediterranean Sea with a much warmer temperature.

This approach however is dependent on the time period used between restarts and processed in one go in WPS. Also, this average temperature is aware of temperatures for the whole restart period, before they actually would affect the lake temperature.

To avoid this and to have flexibility in the amount of days back in time affecting surface lake temperatures, this script (tavgsfc.py) processes met_em files to add the TAVGSFC as a running average of the last 15 days. The amount of days is tunable and we can discuss its value. This will likely depend on the season and latitude, but I think it is an improvement upon the current approach of constant lake temperature for long periods.

Note that, while the 15-day buffer is filling, TAVGSFC is filled with increasing time window averages. This should not be a problem since these initial days will be part of the spin up anyway. Note also that, unlike `avg_tsfc.exe`, this script is applied to met_em files produced by metgrid directly, not to the intermediate files produced by ungrib.